### PR TITLE
Networklogger Undefined Case Fix

### DIFF
--- a/src/networklogger.ts
+++ b/src/networklogger.ts
@@ -96,12 +96,12 @@ class GleapNetworkIntercepter {
   start() {
     this.setStopped(false);
     this.interceptNetworkRequests({
-      onFetch: (params: any, gleapRequestId: any) => {
-        if (this.stopped) {
+      onFetch: (params: any[], gleapRequestId: any) => {
+        if (this.stopped || params.length === 0) {
           return;
         }
 
-        if (params.length >= 2) {
+        if (params.length >= 2 && params[1] !== undefined) {
           var method = params[1].method ? params[1].method : 'GET';
           this.requests[gleapRequestId] = {
             request: {


### PR DESCRIPTION
## Description
When Network Logging is enabled within the gleap dashboard the following error appears and prevents some network requests from finishing. 

` undefined is not an object (evaluating 's[1].method')`

This can be traced to [`networklogger.ts`](https://github.com/GleapSDK/ReactNative-SDK/blob/main/src/networklogger.ts#L104) to the following code snippet: 

```
onFetch: (params: any, gleapRequestId: any) => {
        if (this.stopped) {
          return;
        }

        if (params.length >= 2) {
          var method = params[1].method ? params[1].method : 'GET';
          this.requests[gleapRequestId] = {
            request: {
              payload: this.preparePayload(params[1].body),
              headers: params[1].headers,
            },
            type: method,
            url: params[0],
            date: new Date(),
          };
        } else {
          this.requests[gleapRequestId] = {
            request: {},
            url: params[0],
            type: 'GET',
            date: new Date(),
          };
        }

        this.cleanRequests();
},
```

Within the above code, we have a `params` validation for length, however, nothing checks if that element is undefined. Meaning that the object `method` could not exist within with `params[1]` and the same for `body`  

### Solutions 
~~`   if (params.length >= 2) {`~~

changed to protect against undefined
`if (params.length >= 2 && params[1] !== undefined) {`

### Improvements
We also don't check if `params` is undefined and/or an array. This can cause the else conditional to fail if params[0] does not exist. To fix this we can better define the type params to `any[]` and check if `params.length === 0`

## Version
 7.0.11 and Lower