### PR TITLE
fix: prevent error on fetchFailed

### DIFF
--- a/src/networklogger.ts
+++ b/src/networklogger.ts
@@ -165,12 +165,14 @@ class GleapNetworkIntercepter {
           });
       },
       onFetchFailed: (_err: any, gleapRequestId: any) => {
-        if (this.stopped) {
+        if (this.stopped || !gleapRequestId) {
           return;
         }
 
-        this.requests[gleapRequestId].success = false;
-        this.calcRequestTime(gleapRequestId);
+        if (this.requests && this.requests[gleapRequestId]) {
+          this.requests[gleapRequestId].success = false;
+          this.calcRequestTime(gleapRequestId);
+        }
         this.cleanRequests();
       },
       onOpen: (request: any, args: string | any[]) => {


### PR DESCRIPTION
A quick fix to prevent error during `onFetchFailed` if there is no `gleapRequestId` or if `requests` does not include `gleapRequestId`.

fixes: https://github.com/GleapSDK/ReactNative-SDK/issues/13