### PR TITLE
v16.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 16.4.3
+Updated native iOS dependency to 16.4.3
+(fixes info cards scrolling in two places at once, and flickering in portrait, when the content is taller than the screen)
+Native Android dependency stays on 16.4.2 (unaffected)
+
 ## 16.4.2
 Updated native iOS dependency to 16.4.2
 Updated native Android dependency to 16.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gleapsdk",
-  "version": "16.4.2",
+  "version": "16.4.3",
   "description": "Know exactly why and how a bug happened. Get reports with screenshots, live action replays and all of the important metadata every time.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-gleapsdk.podspec
+++ b/react-native-gleapsdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "Gleap", "16.4.2"
+  s.dependency "Gleap", "16.4.3"
 end


### PR DESCRIPTION
### What moved

| pin | from | to |
|---|---|---|
| package version | 16.4.2 | **16.4.3** |
| iOS `Gleap` pod | 16.4.2 | **16.4.3** |
| Android `gleap-android-sdk` | 16.4.2 | 16.4.2 (unchanged) |

### Why Android stays on 16.4.2

Android never had the bug. It sizes its WebView to the *visible* window, so the info card only ever had one place to scroll — the double-scroll and the portrait flicker were iOS-only (GleapSDK/Gleap-iOS-SDK#30). There is also no `io.gleap:gleap-android-sdk:16.4.3` on Maven Central to point at; pinning one would ship a package whose Android build cannot resolve, which is how the 16.4.2 release got stuck.

Say the word if you would rather cut a no-op Android 16.4.3 to keep the versions in lockstep, and I will redo the pins.

### Verified

`Gleap 16.4.3` is live on the CocoaPods trunk and `gleap-android-sdk 16.4.2` is on Maven Central, so both pins resolve. Podspec syntax and manifest parsing checked.

`bob build` clean (commonjs, module and typescript targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)