### PR TITLE
chore: release 16.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 16.4.5
+Updated native iOS dependency to 16.4.5
+Updated native Android dependency to 16.4.5
+(redesigned in-app notifications: contained cards with the sender and time inside the card, a collapsible notification stack, and the rounded-square bot avatar — matching the JavaScript SDK)
+
 ## 16.4.3
 Updated native iOS dependency to 16.4.3
 (fixes info cards scrolling in two places at once, and flickering in portrait, when the content is taller than the screen)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-native:+"
-  implementation group: 'io.gleap', name: 'gleap-android-sdk', version: '16.4.2'
+  implementation group: 'io.gleap', name: 'gleap-android-sdk', version: '16.4.5'
 
   if(rootProject && rootProject.ext) {
     if(rootProject.ext.targetSdkVersion == 30 || rootProject.ext.compileSdkVersion == 30) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gleapsdk",
-  "version": "16.4.3",
+  "version": "16.4.5",
   "description": "Know exactly why and how a bug happened. Get reports with screenshots, live action replays and all of the important metadata every time.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-gleapsdk.podspec
+++ b/react-native-gleapsdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "Gleap", "16.4.3"
+  s.dependency "Gleap", "16.4.5"
 end


### PR DESCRIPTION
Release train for **16.4.5** — the redesigned in-app notifications (contained cards, notification stack, rounded-square bot avatar), shipped by the native SDKs.

- Package version → 16.4.5
- iOS pod dependency `Gleap` → 16.4.5 (on CocoaPods ✓)
- Android `gleap-android-sdk` → 16.4.5 (on Maven Central ✓)
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)